### PR TITLE
Add mention to OE FPGA Aquisition Board in docs for Rhythm plugins

### DIFF
--- a/source/User-Manual/Plugins/Rhythm-Plugins.rst
+++ b/source/User-Manual/Plugins/Rhythm-Plugins.rst
@@ -9,7 +9,7 @@ Rhythm Plugins
 .. image:: ../../_static/images/plugins/rhythmfpga/rhythmfpga-01.png
   :alt: Annotated settings interface for the Acquisition Board plugin
 
-.. csv-table:: Streams data from any device running Intan's "Rhythm" firmware. It is currently compatible with both the `Open Ephys acquisition board <https://open-ephys.org/acq-board>`__ and the `Intan RHD USB Interface Board <https://intantech.com/RHD_USB_interface_board.html>`__. Support for additional Intan hardware is coming soon.
+.. csv-table:: Streams data from any device running Intan's "Rhythm" firmware. It is currently compatible with the `Open Ephys acquisition board <https://open-ephys.org/acq-board>`__ and the `Intan RHD USB Interface Board <https://intantech.com/RHD_USB_interface_board.html>`__ by selecting the appropriate processor (Acquisition Board and Intan RHD USB). The Open Ephys FPGA version of the Acquisition Board needs the plugin OE FGPA Acquisition Board which works in the same way.
    :widths: 18, 80
 
    "*Plugin Type*", "Source"
@@ -32,7 +32,7 @@ On the left-hand side of the module, there are slots for each of 8 headstages (A
 Sample rate selection
 #######################
 
-Sample rates between 1 and 30 kHz can be selected with this drop-down menu. This will determine the sample rate for all headstages, digital inputs, and ADCs.
+Sample rates between 1 and 30 kHz can be selected with this drop-down menu. This will determine the sample rate for all headstages, digital inputs, and ADCs. Please note that available sample rates can vary between different hardware.
 
 
 Bandwidth interface


### PR DESCRIPTION
- added mention to the OE FPGA Acquisition board plugin, until we unify them (it doesn't warrant a separate plugin page sicne they work in the same way)
- removed mention about upcoming support for other Intan hardware - I actually don't know the status of this but it took up space
- added brief comments that sampling rates may differ across devices since the new FPGA has a couple less option in the drop-down menu.