### PR TITLE
added "signed" to 16-bit integers in continuous data for clarity

### DIFF
--- a/source/User-Manual/Recording-data/Binary-format.rst
+++ b/source/User-Manual/Recording-data/Binary-format.rst
@@ -60,7 +60,7 @@ Continuous data is written separately for each stream within a processor (a bloc
 
 Each **continuous** directory contains the following files:
 
-* :code:`continuous.dat`: A simple binary file containing *N* channels x *M* samples 16-bit integers in little-endian format. Data is saved as :code:`ch1_samp1, ch2_samp1, ... chN_samp1, ch1_samp2, ch2_samp2, ..., chN_sampM`. The value of the least significant bit needed to convert the 16-bit integers to physical units is specified in the :code:`bitVolts` field of the relevant channel in the :code:`structure.oebin` JSON file. For "headstage" channels, multiplying by :code:`bitVolts` converts the values to microvolts, whereas for "ADC" channels, :code:`bitVolts` converts the values to volts.
+* :code:`continuous.dat`: A simple binary file containing *N* channels x *M* samples signed 16-bit integers in little-endian format. Data is saved as :code:`ch1_samp1, ch2_samp1, ... chN_samp1, ch1_samp2, ch2_samp2, ..., chN_sampM`. The value of the least significant bit needed to convert the signed 16-bit integers to physical units is specified in the :code:`bitVolts` field of the relevant channel in the :code:`structure.oebin` JSON file. For "headstage" channels, multiplying by :code:`bitVolts` converts the values to microvolts, whereas for "ADC" channels, :code:`bitVolts` converts the values to volts.
 
 * :code:`sample_numbers.npy`: A numpy array containing *M* 64-bit integers that represent the index of each sample in the :code:`.dat` file since the start of acquisition. **Note:** This file was called :code:`timestamps.npy` in GUI version 0.5.X. To avoid ambiguity, "sample numbers" always refer to integer sample index values starting in version 0.6.0.
 


### PR DESCRIPTION
I made the change only for continuous data. Would be helpful to track down any others.
There is still one 16-bit integer unspecified in Line 80 * :code:`states.npy`:  numpy array of *N* 16-bit integers