### PR TITLE
Update calibration file locations for Neuropixels PXI and OneBox plugins

### DIFF
--- a/source/User-Manual/Exploring-the-user-interface.rst
+++ b/source/User-Manual/Exploring-the-user-interface.rst
@@ -174,6 +174,6 @@ Log files are written to :code:`/Users/<username>/Library/Application Support/op
 Windows
 ---------
 
-Log files are written to :code:`C:\\Users\\<username>\\AppData\\Local\\OpenEphys\\configs-api10`.
+Log files are written to :code:`C:\\Users\\<username>\\AppData\\Local\\Open Ephys\\configs-api10`.
 
 .. _Ableton Live: https://www.ableton.com/en/live/

--- a/source/User-Manual/Plugins/Neuropixels-PXI.rst
+++ b/source/User-Manual/Plugins/Neuropixels-PXI.rst
@@ -113,7 +113,15 @@ and one file for each 2.0 probe:
 
 Any probes detected by the Neuropixels PXI plugin will be calibrated automatically when the plugin is loaded, provided that calibration files are stored in one of the following locations:
 
+For GUI versions prior to v1.0.0:
+
 * :code:`C:\\ProgramData\\Open Ephys\\CalibrationInfo\\<probe_serial_number>` (recommended - note that **ProgramData** may be a hidden folder on your system, so you'll need to change the File Explorer options to show hidden files)
+
+For GUI versions 1.0.0 and later:
+
+* :code:`C:\\Users\\<username>\\AppData\\Local\\OpenEphys\\CalibrationInfo\\<probe_serial_number>` (recommended - note that **AppData** may be a hidden folder on your system, so you'll need to change the File Explorer options to show hidden files)
+
+For any version of the GUI:
 
 * :code:`<open-ephys-executable-folder>\\CalibrationInfo\\<probe_serial_number>` (if you used the Open Ephys installer, the executable will be located in :code:`C:\\Program Files\\Open Ephys`)
 

--- a/source/User-Manual/Plugins/Neuropixels-PXI.rst
+++ b/source/User-Manual/Plugins/Neuropixels-PXI.rst
@@ -119,7 +119,7 @@ For GUI versions prior to v1.0.0:
 
 For GUI versions 1.0.0 and later:
 
-* :code:`C:\\Users\\<username>\\AppData\\Local\\OpenEphys\\CalibrationInfo\\<probe_serial_number>` (recommended - note that **AppData** may be a hidden folder on your system, so you'll need to change the File Explorer options to show hidden files)
+* :code:`C:\\Users\\<username>\\AppData\\Local\\Open Ephys\\CalibrationInfo\\<probe_serial_number>` (recommended - note that **AppData** may be a hidden folder on your system, so you'll need to change the File Explorer options to show hidden files)
 
 For any version of the GUI:
 

--- a/source/User-Manual/Plugins/OneBox.rst
+++ b/source/User-Manual/Plugins/OneBox.rst
@@ -137,7 +137,7 @@ For GUI versions prior to v1.0.0:
 
 For GUI versions 1.0.0 and later:
 
-* :code:`C:\\Users\\<username>\\AppData\\Local\\OpenEphys\\CalibrationInfo\\<probe_serial_number>` (recommended - note that **AppData** may be a hidden folder on your system, so you'll need to change the File Explorer options to show hidden files)
+* :code:`C:\\Users\\<username>\\AppData\\Local\\Open Ephys\\CalibrationInfo\\<probe_serial_number>` (recommended - note that **AppData** may be a hidden folder on your system, so you'll need to change the File Explorer options to show hidden files)
 
 For any version of the GUI:
 

--- a/source/User-Manual/Plugins/OneBox.rst
+++ b/source/User-Manual/Plugins/OneBox.rst
@@ -130,7 +130,16 @@ and one file for each 2.0 probe:
 
 Any probes detected by the OneBox plugin will be calibrated automatically when the plugin is loaded, provided that calibration files are stored in one of the following locations:
 
+
+For GUI versions prior to v1.0.0:
+
 * :code:`C:\\ProgramData\\Open Ephys\\CalibrationInfo\\<probe_serial_number>` (recommended - note that **ProgramData** may be a hidden folder on your system, so you'll need to change the File Explorer options to show hidden files)
+
+For GUI versions 1.0.0 and later:
+
+* :code:`C:\\Users\\<username>\\AppData\\Local\\OpenEphys\\CalibrationInfo\\<probe_serial_number>` (recommended - note that **AppData** may be a hidden folder on your system, so you'll need to change the File Explorer options to show hidden files)
+
+For any version of the GUI:
 
 * :code:`<open-ephys-executable-folder>\\CalibrationInfo\\<probe_serial_number>` (if you used the Open Ephys installer, the executable will be located in :code:`C:\\Program Files\\Open Ephys`)
 


### PR DESCRIPTION

  - Prior to v1.0.0: `C:\ProgramData\Open Ephys\CalibrationInfo\<probe_serial_number>`
  - v1.0.0 and later: `C:\Users\<username>\AppData\Local\OpenEphys\CalibrationInfo\<probe_serial_number>`
  - Any version: `<open-ephys-executable-folder>\CalibrationInfo\<probe_serial_number>`