### PR TITLE
Update ONIX plugin documentation for gateware version

### DIFF
--- a/source/User-Manual/Plugins/Onix-Source.rst
+++ b/source/User-Manual/Plugins/Onix-Source.rst
@@ -68,11 +68,11 @@ Plugin Configuration
   please consider adding them to the `GitHub repo <https://github.com/open-ephys-plugins/onix-source/issues>`__.
 
 .. note:: 
-  The ONIX Source plugin requires the ONIX PCIe Host Firmware to be version 2.0 or higher. If you have an 
-  older version of the firmware, you will need to upgrade it to use this plugin. Please follow the
-  `Updating Firmware in Windows 
-  <https://open-ephys.github.io/onix-docs/Hardware%20Guide/PCIe%20Host/updating-firmware.html#pcie-host-firmware-update>`__ 
-  portion of the hardware documentation to update your PCIe controller firmware.
+  The ONIX Source plugin requires the ONIX PCIe Host Gateware to be version 2.0 or higher. If you have an 
+  older version of the gateware, you will need to upgrade it to use this plugin. Please follow the
+  `Updating Gateware in Windows 
+  <https://open-ephys.github.io/onix-docs/Hardware%20Guide/PCIe%20Controller/updating-gateware.html#updating-pcie-controller-gateware-in-windows>`__ 
+  portion of the hardware documentation to update your PCIe controller gateware.
 
 The ONIX Source plugin allows you to stream data from the ONIX acquisition system. This plugin
 assumes that you have an ONIX Breakout Board connected and powered on before adding the plugin to

--- a/source/conf.py
+++ b/source/conf.py
@@ -238,11 +238,13 @@ linkcheck_ignore = [
     'https://labstreaminglayer.org/#/',
     'https://discord.gg/jmnneS85CY',
     'https://store-usa.arduino.cc/*',
-    'https://openbci.com/*'
+    'https://openbci.com/*',
+    'https://elifesciences.org/*'
 ]
 
 linkcheck_allowed_redirects = {
-    r"https://iopscience.iop.org/article/.*": r"https://validate.perfdrive.com/.*"
+    r"https://iopscience.iop.org/article/.*": r"https://validate.perfdrive.com/.*",
+    "https://help.kontex.io/portal/en/home": "https://erp.kontex.io/helpcenter"
 }
 
 extensions.append("sphinx_tabs.tabs")


### PR DESCRIPTION
The ONIX docs have been updated to adhere to the terminology of the ONI spec, which led to a broken link here. While fixing the link, I've also updated the terminology from firmware to gateware to be in line with the specification.