### PR TITLE
Skip checking elifesciences.org link

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -239,7 +239,8 @@ linkcheck_ignore = [
     'https://discord.gg/jmnneS85CY',
     'https://store-usa.arduino.cc/*',
     'https://openbci.com/*',
-    'https://ftdichip.com/drivers/d3xx-drivers/'
+    'https://ftdichip.com/drivers/d3xx-drivers/',
+    'https://elifesciences.org/articles/77772'
 ]
 
 linkcheck_allowed_redirects = {


### PR DESCRIPTION
- Link is throwing a 406 error. Might be worth checking if other ignore links could be fixed by changing the user header.